### PR TITLE
Updated impurity_improvement to match newer declaration

### DIFF
--- a/hellinger_distance_criterion.pyx
+++ b/hellinger_distance_criterion.pyx
@@ -23,12 +23,8 @@ cdef class HellingerDistanceCriterion(ClassificationCriterion):
        
         return impurity_right + impurity_left
     
-    cdef double impurity_improvement(self, double impurity) nogil:
-        cdef double impurity_left
-        cdef double impurity_right
-
-        self.children_impurity(&impurity_left, &impurity_right)
-
+    cdef double impurity_improvement(self, double impurity_parent, double impurity_left, double impurity_right ) nogil:
+        
         return impurity_right + impurity_left
     
     cdef double node_impurity(self) nogil:


### PR DESCRIPTION
* As mentioned in https://github.com/EvgeniDubov/hellinger-distance-criterion/issues/9#issue-853080199, sklearn's declaration has been updated since v0.24.1
* Instead of calling children_impurity from the method, the method gets
the right and left impurity as arguments.